### PR TITLE
Minor upgrades

### DIFF
--- a/db/wedeploy.json
+++ b/db/wedeploy.json
@@ -1,6 +1,6 @@
 {
   "id": "db",
-  "image": "mysql",
+  "image": "mariadb",
   "env": {
     "MYSQL_ROOT_PASSWORD": "passw0rd"
   },

--- a/wp/Dockerfile
+++ b/wp/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.8.2
+FROM wordpress:latest
 
 # Bundle your source
 ADD . /var/www/html

--- a/wp/Dockerfile
+++ b/wp/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:latest
+FROM wordpress
 
 # Bundle your source
 ADD . /var/www/html


### PR DESCRIPTION
I think using the latest available version from WordPress is better than making it set in stone.

Also, if we would like to show an example of using tags in wedeploy.json, having a seperate service with wp-cli would be better and we can show off shared volumes in this way as well. But that's an another ~~story~~ pull request. 😄 